### PR TITLE
changing the minZoom props on the map

### DIFF
--- a/src/components/Map/index.jsx
+++ b/src/components/Map/index.jsx
@@ -13,7 +13,7 @@ const Map = ({ zoom, position, style, onPositionChanged, onClick }) => {
     <div className={styles.wrapper}>
       <LeafletMap
         maxZoom={14}
-        minZoom={4}
+        minZoom={8}
         center={position}
         zoom={zoom}
         onMoveEnd={onPositionChanged}


### PR DESCRIPTION
-Changing the minZoom property on the leaflet map to  limit the dezoom possibility for the user in order to give him a better view